### PR TITLE
fix: TypeError due to missing document instance

### DIFF
--- a/src/Lock.vue
+++ b/src/Lock.vue
@@ -156,7 +156,7 @@
 
       this.data.disabled = this.disabled;
       this.data.onActivation = () => {
-        this.originalFocusedElement = this.originalFocusedElement || document.activeElement;
+        this.originalFocusedElement = this.originalFocusedElement || document && document.activeElement;
       };
 
       if (!instances.length) {


### PR DESCRIPTION
I found a TypeError similar to the one described in #14, when testing a
Vue component using vue-focus-lock using Jest 25. The trace reads:

    TypeError: Cannot read property 'activeElement' of null
        at data.onActivation (/Users/danirod/Workspace/..../node_modules/vue-focus-lock/dist/index.js:483:79)
        at Immediate.activateTrap (/Users/danirod/Workspace/..../node_modules/vue-focus-lock/dist/index.js:382:9)
        at processImmediate (internal/timers.js:439:21)
    /Users/danirod/Workspace/..../node_modules/vue-focus-lock/dist/index.js:483
          _this.originalFocusedElement = _this.originalFocusedElement || document.activeElement;

By patching this line in a similar fashion to
da4cf128da94ac62e2cdae95d6ba0ea9bc558852, it is possible to
shortcircuit the assignment so that it handles the cases where document
is null.