### PR TITLE
Made the "invisible divs" aria hidden

### DIFF
--- a/src/Lock.vue
+++ b/src/Lock.vue
@@ -1,13 +1,13 @@
 <template>
     <div>
-        <div v-if="hasLeadingGuards" :tabIndex="disabled ? -1 : 0" :style="hidden"></div>
-        <div v-if="hasLeadingGuards" :tabIndex="disabled ? -1 : 1" :style="hidden"></div>
+        <div v-if="hasLeadingGuards" :tabIndex="disabled ? -1 : 0" :style="hidden" aria-hidden="true"></div>
+        <div v-if="hasLeadingGuards" :tabIndex="disabled ? -1 : 1" :style="hidden" aria-hidden="true"></div>
 
         <div @focusout="onBlur" v-bind="groupAttr" data-lock>
             <slot></slot>
         </div>
 
-        <div v-if="hasTailingGuards" :tabIndex="disabled ? -1 : 0" :style="hidden"></div>
+        <div v-if="hasTailingGuards" :tabIndex="disabled ? -1 : 0" :style="hidden" aria-hidden="true"></div>
     </div>
 </template>
 


### PR DESCRIPTION
When using a screen reader, it will try to focus on the divs, creating a bad user experience of the screen reader user. At least, please make an identifier for the divs so I can hide them with javascript in our project.