### PR TITLE
fix: externalize vue-demi

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const path = require('path')
 
 module.exports = {
   entry: './src/index.js',
+  externals: 'vue-demi',
   output: {
     path: path.resolve(__dirname, './dist/'),
     filename: 'index.js',


### PR DESCRIPTION
Adds vue-demi as library external, as it depends on npm post-install actions that can't happen when it's bundled by Webpack. Resolves #25.